### PR TITLE
Config and Plugin Support

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,16 +11,10 @@ app.get("/:user/:repo/compile", (req, res) => {
   const user = req.params.user;
   const repo = req.params.repo;
 
-  try {
-    util.compileDocs(user, repo).then(() => {
-      util.serveDocs(app, user, repo);
-      res.send(`Successfully Compiled Docs! View them at /${user}/${repo}`);
-    });
-  } catch (error) {
-    res.send(
-      `Oops. We couldn't render these docs. Check your config if you have one and try again!`
-    );
-  }
+  util.compileDocs(user, repo).then(() => {
+    util.serveDocs(app, user, repo);
+    res.send(`Successfully Compiled Docs! View them at /${user}/${repo}`);
+  });
 });
 
 app.listen(port, () =>

--- a/app.js
+++ b/app.js
@@ -1,15 +1,9 @@
 const express = require("express");
 
 const util = require("./util");
+
 const app = express();
 const port = 3000;
-
-let defaultConfig = {
-  name: "",
-  description: "Description",
-  plugins: [],
-  theme: "",
-};
 
 app.get("/", (req, res) => res.send("Hello World!"));
 
@@ -17,10 +11,16 @@ app.get("/:user/:repo/compile", (req, res) => {
   const user = req.params.user;
   const repo = req.params.repo;
 
-  util.getReadme(user, repo).then(() => {
-    util.serveDocs(app, user, repo);
-    res.send(`Successfully Compiled Docs! View them at /${user}/${repo}`);
-  });
+  try {
+    util.compileDocs(user, repo).then(() => {
+      util.serveDocs(app, user, repo);
+      res.send(`Successfully Compiled Docs! View them at /${user}/${repo}`);
+    });
+  } catch (error) {
+    res.send(
+      `Oops. We couldn't render these docs. Check your config if you have one and try again!`
+    );
+  }
 });
 
 app.listen(port, () =>

--- a/config.json
+++ b/config.json
@@ -1,0 +1,5 @@
+{
+  "description": "Description",
+  "plugins": [],
+  "gaCode": ""
+}

--- a/docsify.js
+++ b/docsify.js
@@ -1,5 +1,26 @@
+// Generates docsify enabled html with no config
 function generateHTML(user, repo) {
   return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"/><title>${repo}</title><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/><meta name="description" content="Description"/> <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0"/> <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css"/> </head> <body> <div id="app"></div><script>window.$docsify={name: '${repo}', repo: '${user}/${repo}'}; </script> <script src="//cdn.jsdelivr.net/npm/docsify@4"></script> </body></html>`;
 }
 
-module.exports = { generateHTML };
+// Generated docsify enabled html with config and plugins
+function generateHtmlWithConfig(config) {
+  if (config.enablePlugins) {
+    let ga = ""; // google analytics code
+    let search = ""; // search path
+
+    if (config.plugins.ga) {
+      ga = `, ga: ${config.gaCode}`;
+    }
+    if (config.plugins.search) {
+      search = ', search: ["/"]';
+    }
+
+    return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"/><title>${config.repo}</title><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/><meta name="description" content="${config.description}"/> <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0"/> <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css"/> </head> <body> <div id="app"></div><script>window.$docsify={name: '${config.repo}', repo: '${config.user}/${config.repo}'${ga}${search}}; </script> <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>${config.plugins.tags}</body></html>`;
+  }
+
+  // If no plugins, but config exists for description
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"/><title>${config.repo}</title><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/><meta name="description" content="${config.description}"/> <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0"/> <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css"/> </head> <body> <div id="app"></div><script>window.$docsify={name: '${config.repo}', repo: '${config.user}/${config.repo}'}; </script> <script src="//cdn.jsdelivr.net/npm/docsify@4"></script> </body></html>`;
+}
+
+module.exports = { generateHTML, generateHtmlWithConfig };

--- a/docsify.js
+++ b/docsify.js
@@ -5,22 +5,19 @@ function generateHTML(user, repo) {
 
 // Generated docsify enabled html with config and plugins
 function generateHtmlWithConfig(config) {
-  if (config.enablePlugins) {
-    let ga = ""; // google analytics code
-    let search = ""; // search path
+  let ga = ""; // google analytics code
+  let search = ""; // search path
 
+  if (config.enablePlugins) {
     if (config.plugins.ga) {
       ga = `, ga: ${config.gaCode}`;
     }
     if (config.plugins.search) {
       search = ', search: ["/"]';
     }
-
-    return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"/><title>${config.repo}</title><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/><meta name="description" content="${config.description}"/> <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0"/> <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css"/> </head> <body> <div id="app"></div><script>window.$docsify={name: '${config.repo}', repo: '${config.user}/${config.repo}'${ga}${search}}; </script> <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>${config.plugins.tags}</body></html>`;
   }
 
-  // If no plugins, but config exists for description
-  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"/><title>${config.repo}</title><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/><meta name="description" content="${config.description}"/> <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0"/> <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css"/> </head> <body> <div id="app"></div><script>window.$docsify={name: '${config.repo}', repo: '${config.user}/${config.repo}'}; </script> <script src="//cdn.jsdelivr.net/npm/docsify@4"></script> </body></html>`;
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"/><title>${config.repo}</title><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/><meta name="description" content="${config.description}"/> <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0"/> <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css"/> </head> <body> <div id="app"></div><script>window.$docsify={name: '${config.repo}', repo: '${config.user}/${config.repo}'${ga}${search}}; </script> <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>${config.plugins.tags}</body></html>`;
 }
 
 module.exports = { generateHTML, generateHtmlWithConfig };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "docsify-up",
   "version": "1.0.0",
   "description": "- https://documentup.com/jeromegn/documentup\r - https://github.com/docsifyjs/docsify/issues/217",
-  "main": "index.js",
+  "main": "app.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/plugins.js
+++ b/plugins.js
@@ -1,0 +1,34 @@
+function addPlugins(pluginList) {
+  let pluginConfig = {
+    ga: false,
+    search: false,
+    tags: "",
+  };
+  let scriptTags = "";
+  for (let i = 0; i < pluginList.length; i++) {
+    if (pluginList[i] == "docsify-copy-code") {
+      scriptTags +=
+        "<script src='//cdn.jsdelivr.net/npm/docsify-copy-code'></script>";
+    }
+    if (pluginList[i] == "full-text-search") {
+      scriptTags +=
+        "<script src='//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js'></script>";
+      pluginConfig.search = true;
+    }
+    if (pluginList[i] == "google-analytics") {
+      pluginConfig.ga = true;
+    }
+    if (pluginList[i] == "emoji") {
+      scriptTags +=
+        "<script src='//cdn.jsdelivr.net/npm/docsify/lib/plugins/emoji.min.js'></script>";
+    }
+    if (pluginList[i] == "zoom-image") {
+      scriptTags +=
+        "<script src='//cdn.jsdelivr.net/npm/docsify/lib/plugins/zoom-image.min.js'></script>";
+    }
+  }
+  pluginConfig.tags = scriptTags;
+  return pluginConfig;
+}
+
+module.exports = { addPlugins };

--- a/util.js
+++ b/util.js
@@ -26,12 +26,10 @@ function isDiffReadme(user, repo, readmeData) {
 // Writes all the required files
 async function writeDocs(user, repo, readmeData) {
   const config = await getConfig(user, repo);
-
-  if (isConfigDefault(config)) {
-    writeDocsWithDefaultConfig(user, repo, readmeData);
-  } else {
-    // TODO: if config is not default? --> plugin integration!!!
+  if (config) {
     writeDocsWithConfig(user, repo, readmeData, config);
+  } else {
+    writeDocsWithDefaultConfig(user, repo, readmeData);
   }
 }
 
@@ -119,11 +117,6 @@ function serveDocs(app, user, repo) {
   app.use(`/${user}/${repo}`, express.static(`./docs/${user}-${repo}`));
 }
 
-function isConfigDefault(config) {
-  if (config.name != "") return false;
-  return true;
-}
-
 async function getConfig(user, repo) {
   const gitRepo = await axios.get(
     `https://api.github.com/repos/${user}/${repo}/contents`
@@ -142,7 +135,7 @@ async function getConfig(user, repo) {
     const config = await axios.get(configUrl);
     return config.data;
   }
-  return mainConfig;
+  return "";
 }
 
 async function compileDocs(user, repo) {


### PR DESCRIPTION
This PR includes:

## Config

- Now scans `/:user/:repo` for a `.fastdocs.json` config file. This allows fastdocs to know which plugins to add when rendering the docs.
- Defaults to rendering without config if any error is thrown during parsing the config.

_Current Config_:
```json
{
  "description": "Description",
  "plugins": [],
  "gaCode": ""    
}
```
_`gaCode` is only required when `google-analytics` is added to the `plugins` array_

## Plugins
- Added support for most **major plugins** on docsify that were determined to be "lightweight" enough to be added to the fastdocs microservice. These include:
    - `docsify-copy-code`: Adds a "Copy to Clipboard" next to code blocks
    - `full-text-search`: Adds a search bar on the top of the sidebar to quickly search docs
    - `google-analytics`: Support for google analytics
       - Need to provide the google analytics code inside `gaCode` on the config.
    - `emoji`: Renders emoji's in your documentation. (Ex: `:100:` would render to 💯) 
    - `zoom-image`: Adds subtle zooming to images cursor is hovering